### PR TITLE
Updated votes.js to vote for all stock holders

### DIFF
--- a/tests/vote.js
+++ b/tests/vote.js
@@ -2,12 +2,25 @@
 
 console.log("unlocking accounts")
 personal.unlockAccount(eth.accounts[0], "Write here a good, randomly generated, passphrase!")
+personal.unlockAccount(eth.accounts[1], "Write here a good, randomly generated, passphrase!")
+personal.unlockAccount(eth.accounts[2], "Write here a good, randomly generated, passphrase!")
+personal.unlockAccount(eth.accounts[3], "Write here a good, randomly generated, passphrase!")
+personal.unlockAccount(eth.accounts[4], "Write here a good, randomly generated, passphrase!")
+personal.unlockAccount(eth.accounts[5], "Write here a good, randomly generated, passphrase!")
+personal.unlockAccount(eth.accounts[6], "Write here a good, randomly generated, passphrase!")
 
-tx = dao.vote.sendTransaction(id, 1, {from:eth.accounts[0],value:web3.toWei(101, "ether")})
+
+tx = dao.vote.sendTransaction(0, 1, {from:eth.accounts[0],value:web3.toWei(101, "ether"),gas:900000})
+tx = dao.vote.sendTransaction(0, 1, {from:eth.accounts[1],value:web3.toWei(101, "ether"),gas:900000})
+tx = dao.vote.sendTransaction(0, 1, {from:eth.accounts[2],value:web3.toWei(101, "ether"),gas:900000})
+tx = dao.vote.sendTransaction(0, 1, {from:eth.accounts[3],value:web3.toWei(101, "ether"),gas:900000})
+tx = dao.vote.sendTransaction(0, 1, {from:eth.accounts[4],value:web3.toWei(101, "ether"),gas:900000})
+tx = dao.vote.sendTransaction(0, 1, {from:eth.accounts[5],value:web3.toWei(101, "ether"),gas:900000})
+tx = dao.vote.sendTransaction(0, 1, {from:eth.accounts[6],value:web3.toWei(101, "ether"),gas:900000})
+
+
 
 console.log("mining")
 miner.start(1); admin.sleepBlocks(1); miner.stop();
 
 console.log(eth.getTransactionReceipt(tx));
-
-

--- a/tests/vote.js
+++ b/tests/vote.js
@@ -18,8 +18,6 @@ tx = dao.vote.sendTransaction(0, 1, {from:eth.accounts[4],value:web3.toWei(101, 
 tx = dao.vote.sendTransaction(0, 1, {from:eth.accounts[5],value:web3.toWei(101, "ether"),gas:900000})
 tx = dao.vote.sendTransaction(0, 1, {from:eth.accounts[6],value:web3.toWei(101, "ether"),gas:900000})
 
-
-
 console.log("mining")
 miner.start(1); admin.sleepBlocks(1); miner.stop();
 


### PR DESCRIPTION
There was a bug where new_prop.js stored id of the proposal as a string. When I tried to vote using this string. It required huge amounts of gas and ever complete. But I assume that is the default fail behavior here. 

I ran into a problem continuing from here. I cant test executeProposal without waiting for the 30 days (debate period) to pass. Will think about it.