### PR TITLE
add fucntion name for buyToken

### DIFF
--- a/Crowdfunding.sol
+++ b/Crowdfunding.sol
@@ -69,7 +69,7 @@ contract Crowdfunding is CrowdfundingInterface, Token {
     }
 
 
-    function () {
+    function buyToken() {
         buyTokenProxy(msg.sender);
     }
 


### PR DESCRIPTION
I found buyToken function in [ABI](https://github.com/slockit/smart-contract/blob/master/tests/deploy.js#L11), but I could not find the function in the contract.

And then I found this [commit](https://github.com/slockit/smart-contract/commit/4cd261d147bbf27a1325242e0509d45c0a1e645b).

I just found a [example] (https://solidity.readthedocs.org/en/latest/solidity-by-example.html#simple-open-auction) from solidity document.
```
    function () {
        // This function gets executed if a
        // transaction with invalid data is sent to
        // the contract or just ether without data.
        // We revert the send so that no-one
        // accidentally loses money when using the
        // contract.
        throw;
    }
```
According to the comment, the function without a name gets executed if a transaction with invalid data is sent to the contract or just ether without data.

So I think the before one is better.