### PR TITLE
Making explicit that `minQuorum` is never called for new service provider proposals.

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -316,7 +316,7 @@ contract DAO is DAOInterface, Token, Crowdfunding {
 
     function minQuorum(bool _newServiceProvider, uint _value) internal returns (uint _minQuorum) {
         if (_newServiceProvider)
-            return total_supply / 2;
+            throw;
         else
             return total_supply / 5 + _value / 3;
     }


### PR DESCRIPTION
`minQuorum()` is only called from `executeProposal()` and never for new service provider proposals.  As a result, the `if`-condition in `minQuorum()` is never true.  This pull-request suggests removal of the never-used `total_supply / 2`.