### PR TITLE
Enforce votingDeadline in vote().

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -199,6 +199,7 @@ contract DAO is DAOInterface, Token, Crowdfunding {
     function vote(uint _proposalNumber, bool _supportsProposal) onlyShareholders returns (uint _voteID) {
         Proposal p = proposals[_proposalNumber];
         if (p.voted[msg.sender] == true) throw;
+        if (now >= p.votingDeadline) throw;
 
         _voteID = p.votes.length++;
         p.votes[_voteID] = Vote({inSupport: _supportsProposal, voter: msg.sender});


### PR DESCRIPTION
Before this commit, the Token holders were able to vote even after the votingDeadline of a proposal.  A proposal could fail to reach the minimal quorum, stay dormant for a year, and suddenly get voted for, and be passed.  (This might be already part of the plan, but in that case the name of variable `votingDeadline` should be changed.)