### PR TITLE
Prevent repeated calls to halfMinQuorum()

### DIFF
--- a/DAO.sol
+++ b/DAO.sol
@@ -439,6 +439,7 @@ contract DAO is DAOInterface, Token, TokenSale {
 
     function halfMinQuorum() returns (bool _success){
         if (lastTimeMinQuorumMet < (now - 52 weeks)) {
+            lastTimeMinQuorumMet = now;
             minQuorumDivisor *= 2;
             return true;
         }


### PR DESCRIPTION
Before this commit, after a year from the last quorum formation,
`halfMinQuorum()` could be called successfully for many times.
This reduces the minimum quorum to almost zero.

This commit prevents this by resetting the timer every time
`halfMinQuorum()` is successfully called.